### PR TITLE
Changed custom.css target to home dir configuration

### DIFF
--- a/jupythemer/jupythemer.py
+++ b/jupythemer/jupythemer.py
@@ -6,12 +6,11 @@ import sys
 import argparse
 
 current_dir = os.path.dirname(os.path.realpath(__file__))
-jupyter_dir = os.path.dirname(jupyter.__file__)
-custom_css_filepath = jupyter_dir + '/notebook/static/custom/custom.css'
-
+custom_css_filepath = os.path.join(os.path.expanduser('~'), 'custom', 'custom.css') 
 
 def write_to_css(content):
     try:
+        os.makedirs(os.path.dirname(custom_css_filepath), exist_ok=True)
         with open(custom_css_filepath, 'w') as f:
             f.write(content)
     except:


### PR DESCRIPTION
In this diff I've changed default, per system configuration
to per user configuration. Reason for that being simple -- I have
jupyter in my package manager and would like keeping configs under
my user. Otherwise I have to escalate the permission (sudo
jupyter-thermer) whenever I want making changes to interface, and
cannot easily version control my jupyter configuration.

This diff changes that and writes to user custom.css
