### PR TITLE
Add option for custom path to custom.css

### DIFF
--- a/jupythemer/jupythemer.py
+++ b/jupythemer/jupythemer.py
@@ -12,9 +12,9 @@ notebook_dir = os.path.dirname(notebook.__file__)
 custom_css_filepath = notebook_dir + '/static/custom/custom.css'
 
 
-def write_to_css(content):
+def write_to_css(content, css_path):
     try:
-        with open(custom_css_filepath, 'w') as f:
+        with open(css_path, 'w+') as f:
             f.write(content)
     except:
         print('Error writing to custom.css')
@@ -33,6 +33,8 @@ def run(args=None):
                             default=None, help='background theme styling')
         parser.add_argument('-s', '--show', required=False, dest='show',
                             default=None, help='show available choices')
+        parser.add_argument('-p', '--path', required=False, dest='css_path',
+                            default=custom_css_filepath, help='custom css path.(default:%s)' % custom_css_filepath)
         args = parser.parse_args()
 
     if (args.color is None
@@ -42,7 +44,7 @@ def run(args=None):
             and args.background is None
             and args.show is None):
         print('Jupyter notebook reverted to default style.')
-        write_to_css('')
+        write_to_css('', args.css_path)
         sys.exit()
 
     if args.show in ['color', 'layout', 'typography', 'font', 'background']:
@@ -109,7 +111,7 @@ def run(args=None):
             print('Bad argument passed to --background')
             sys.exit(1)
 
-    write_to_css(content_all)
+    write_to_css(content_all, args.css_path)
     print('Custom jupyter notebook theme created - refresh any open jupyter notebooks to apply theme.')
 
 

--- a/jupythemer/jupythemer.py
+++ b/jupythemer/jupythemer.py
@@ -33,7 +33,7 @@ def run(args=None):
                             default=None, help='background theme styling')
         parser.add_argument('-s', '--show', required=False, dest='show',
                             default=None, help='show available choices')
-        parser.add_argument('-p', '--path', required=False, dest='css_path',
+        parser.add_argument('-p', '--css_path', required=False, dest='css_path',
                             default=custom_css_filepath, help='custom css path.(default:%s)' % custom_css_filepath)
         args = parser.parse_args()
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -4,25 +4,108 @@ import jupyter
 import os
 import unittest
 
+import tempfile
 from collections import namedtuple
 from jupythemer import jupythemer
 from jupythemer.jupythemer import custom_css_filepath
+
+neo_css = '''/*
+    Adapted for jupyter-themer from https://github.com/codemirror
+*/
+
+/* neo theme for codemirror */
+
+/* Color scheme */
+
+.CodeMirror {
+  background-color:#ffffff;
+  color:#2e383c;
+  line-height:1.4375;
+}
+.CodeMirror span.cm-comment { color:#75787b; }
+.CodeMirror span.cm-keyword, .CodeMirror span.cm-property { color:#1d75b3; }
+.CodeMirror span.cm-atom,.CodeMirror span.cm-number { color:#75438a; }
+.CodeMirror span.cm-node,.CodeMirror span.cm-tag { color:#9c3328; }
+.CodeMirror span.cm-string { color:#b35e14; }
+.CodeMirror span.cm-variable,.CodeMirror span.cm-qualifier { color:#047d65; }
+
+
+/* Editor styling */
+
+.CodeMirror pre {
+  padding:0;
+}
+
+.CodeMirror .CodeMirror-gutters {
+  border:none;
+  border-right:10px solid transparent;
+  background-color:transparent;
+}
+
+.CodeMirror .CodeMirror-linenumber {
+  padding:0;
+  color:#e0e2e5;
+}
+
+.CodeMirror .CodeMirror-guttermarker { color: #1d75b3; }
+.CodeMirror .CodeMirror-guttermarker-subtle { color: #e0e2e5; }
+
+.CodeMirror .CodeMirror-cursor {
+  width: auto;
+  border: 0;
+  background: rgba(155,157,162,0.37);
+  z-index: 1;
+}
+
+'''
 
 
 class TestScript(unittest.TestCase):
 
     def setUp(self):
         self.backup = ''
-        with open(custom_css_filepath, 'r') as f:
+        if os.path.isfile(custom_css_filepath):
+            self.fn = custom_css_filepath
+        else:
+            _, self.fn = tempfile.mkstemp()
+
+        with open(self.fn, 'r') as f:
             self.backup = f.read()
 
     def tearDown(self):
-        with open(custom_css_filepath, 'w') as f:
+        with open(self.fn, 'w') as f:
             f.write(self.backup)
 
     def test_color(self):
-        args = namedtuple('args', ('color', 'layout', 'typography', 'font', 'background', 'show'))
-        jupythemer.run(args('neo', None, None, None, None, None))
+        args = namedtuple('args', ('color', 'layout', 'typography', 'font', 'background', 'show', 'css_path'))
+        jupythemer.run(args('neo', None, None, None, None, None, self.fn))
+        with open(self.fn, 'r') as f:
+            content = f.read()
+        print(content)
+        self.assertEqual(content, neo_css)
+
+
+class TestScriptCustomPath(unittest.TestCase):
+
+    def setUp(self):
+        _, self.fn = tempfile.mkstemp()
+
+    def tearDown(self):
+        os.remove(self.fn)
+
+    def test_color(self):
+        args = namedtuple('args', ('color', 'layout', 'typography', 'font', 'background', 'show', 'css_path'))
+
+        with open(self.fn, 'r') as f:
+            content = f.read()
+
+        self.assertEqual(content, '')
+
+        jupythemer.run(args('neo', None, None, None, None, None, self.fn))
+        with open(self.fn, 'r') as f:
+            content = f.read()
+
+        self.assertEqual(content, neo_css)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I have realized just now that there is a similar [pull request](https://github.com/transcranial/jupyter-themer/pull/13).

This pull request simply creates a new command line argument that one can use to specify the correct path to the custom.css file.

According to the personal configuration of anaconda - or how jupyter has been installed, the custom folder may be somewhere else. E.g. in my work laptop it is in ~/.jupyter/custom/, in my personal one it follows the python path.

**Notice**, the `TestScript` was failing on my maching because of a difference in `custom_css_path` and the real one. Hence I also made a `tempfile`